### PR TITLE
Show instruction stack when displaying error/warning/notice

### DIFF
--- a/bass/bassbugs.txt
+++ b/bass/bassbugs.txt
@@ -1,12 +1,3 @@
-bug in: error "string"
-test case:
-error "foo"
-$ bass err.asm
-error: foo
-e.asm:2:1: error "foo"
-bass: assembly failed
-rationale: Should list the line where the macro was invoked? instead of the line in the macro where the error statement is located.
-
 lda #$00		= A9 00
 lda #$0000		= A9 00 00
 lda #0			= A9 00 00

--- a/bass/core/core.cpp
+++ b/bass/core/core.cpp
@@ -143,16 +143,27 @@ void Bass::printInstruction() {
   }
 }
 
+void Bass::printInstructionStack() {
+  printInstruction();
+
+  for(unsigned s = stackFrame.size() - 1; s >= 1; s--) {
+    if(stackFrame[s].invokedBy) {
+      auto& i = *stackFrame[s].invokedBy;
+      print("   ", sourceFilenames[i.fileNumber], ":", i.lineNumber, ":", i.blockNumber, ": ", i.statement, "\n");
+    }
+  }
+}
+
 template<typename... Args> void Bass::notice(Args&&... args) {
   string s = string(std::forward<Args>(args)...);
   print("notice: ", s, "\n");
-  printInstruction();
+  printInstructionStack();
 }
 
 template<typename... Args> void Bass::warning(Args&&... args) {
   string s = string(std::forward<Args>(args)...);
   print("warning: ", s, "\n");
-  printInstruction();
+  printInstructionStack();
 
   if(strict == false) return;
   struct BassWarning {};
@@ -162,7 +173,7 @@ template<typename... Args> void Bass::warning(Args&&... args) {
 template<typename... Args> void Bass::error(Args&&... args) {
   string s = string(std::forward<Args>(args)...);
   print("error: ", s, "\n");
-  printInstruction();
+  printInstructionStack();
 
   struct BassError {};
   throw BassError();

--- a/bass/core/core.hpp
+++ b/bass/core/core.hpp
@@ -65,6 +65,7 @@ protected:
     unsigned ip;
     bool scoped;
 
+    Instruction* invokedBy = nullptr;
     hashset<Macro> macros;
     hashset<Define> defines;
     hashset<Variable> variables;
@@ -108,6 +109,7 @@ protected:
   void write(uint64_t data, unsigned length = 1);
 
   void printInstruction();
+  void printInstructionStack();
   template<typename... Args> void notice(Args&&... args);
   template<typename... Args> void warning(Args&&... args);
   template<typename... Args> void error(Args&&... args);

--- a/bass/core/execute.cpp
+++ b/bass/core/execute.cpp
@@ -139,6 +139,7 @@ bool Bass::executeInstruction(Instruction& i) {
       StackFrame frame;
       stackFrame.append(frame);
       stackFrame.last().ip = ip;
+      stackFrame.last().invokedBy = &i;
       stackFrame.last().scoped = macro().scoped;
 
       if(macro().scoped) {


### PR DESCRIPTION
I have improved the way bass displays errors to the user. After reading bassbugs.txt I thought you would be interested in this.

**Edit:** example:

```
macro assert(test) {
    if !({test}) {
        error "{test}"
    }
}

macro badmacro() {
	assert(1 == 2)
}

badmacro()
```

Gives the output:
```
> bass test.asm 
error: 1 == 2
test.asm:4:1: error "{test}"
   test.asm:9:1: assert(1 == 2)
   test.asm:12:1: badmacro()
bass: assembly failed
```
