### PR TITLE
Validate scope, macro, define, variable and constant names

### DIFF
--- a/bass/core/assemble.cpp
+++ b/bass/core/assemble.cpp
@@ -29,6 +29,7 @@ bool Bass::assemble(const string& statement) {
       setConstant(s.rtrim<1>(":"), pc());
       appendSymfile(s, pc());
     }
+    if(s) validateName(s);
     scope.append(s);
     return true;
   }

--- a/bass/core/core.hpp
+++ b/bass/core/core.hpp
@@ -184,6 +184,7 @@ protected:
   string filepath();
   string text(string s);
   int64_t character(string s);
+  void validateName(const string& name);
 };
 
 // vim:sts=2 sw=2


### PR DESCRIPTION
This commit adds name validation to scope, macro, define, variable and constant names.

I wrote it because of a bug in bass where a typo involving a colon at the end of a line can swallow instructions.

For example; in the following code, the current version of bass will swallow the bra instruction and create an empty file with no errors or warnings.
~~~ asm
arch snes.cpu
origin 0

Loop:
    bra   Loop:
~~~



After implementing this commit, we get the following warning:

    warning: Invalid name: bra Loop
    bass_test.asm:5:1: bra Loop:


The validator emits a warning instead of an error because of bad code that may exist in existing code-bases.