### PR TITLE
Improve documenation formatting to improve readability

### DIFF
--- a/bass/doc/bass.html
+++ b/bass/doc/bass.html
@@ -3,10 +3,12 @@
     <title>bass documentation</title>
     <style type="text/css">
       body {
-        background: #fff;
-        color: #000;
-        font-family: arial, helvetica;
-        font-size: 0.9em;
+        background: #fefcfc;
+        color: #080808;
+        font-family: arial, helvetica, sans-serif;
+        max-width: 50em;
+        margin: 0 auto;
+        padding: 1em;
       }
 
       h1, h2, h3, h4, h5, h6 {
@@ -35,6 +37,10 @@
       p {
         margin: 0em;
         margin-bottom: 1em;
+      }
+
+      p:last-child {
+        margin-bottom: 0em;
       }
 
       pre {


### PR DESCRIPTION
This change mainly limits the length of lines to 50em, so that your eyes don't need to scroll back and forth across the entire screen. It also improves spacing, and tweaks contrast to be easier on the eyes.

While outside the scope of a pull request, it would be nice if this file was moved from /bass/doc/bass.html to /doc/index.html, and github pages was enabled. As far as I can tell, this is really the only documentation for bass available, and it would be nice if it had an easy to access URL such as https://ARM9.github.io/bass, so that you can read the documentation without cloning the repo.