### PR TITLE
Documentation cleanups and nitpicks.

### DIFF
--- a/doc/architectures.md
+++ b/doc/architectures.md
@@ -1,5 +1,5 @@
-# Bass Architectures
-Most compilers can compile code to every target platform by using different backends. Bass is no exception to this, but it offers the possibility to write an custom backend in minutes and by just using an text editor.
+# bass Architectures
+Most compilers can compile code to every target platform by using different backends. bass is no exception to this, but it offers the possibility to write an custom backend in minutes and by just using an text editor.
 
 > **Note:**<br/>
 > Speaking of architecture-files usually refers to string files used by the Table-Architecture-Backend.
@@ -10,20 +10,19 @@ Architecture files are simply text files that have one instruction in each line.
 Our syntax is simple: The left side represents what you see in the assembly file, the right side is the result that you want to see as binary output.
 
 ```cpp
-// <LFH> ;<RHS>
+// <LHS> ;<RHS>
 // WDC6502
 nop        ;$ea
-asl #*08   ;*a:$0a
 ```
 > Please keep in mind to always use **lower** case.
 
 The example is straight forward: `nop` is translated to the value `0xEA` and will be put into the current position of the output binary.
 
-### LFH Tokens
-Bass always tries to give as least limitations to architecture files as possible. The LFH syntax only know two reserved states:
+### LHS Tokens
+bass always tries restrict architecture files as little as possible. The LHS syntax only know two reserved states:
 
 * The first character is an `#`, because this indicates defines or command calls
-* `*` indicate parameters and how many bit's are used.
+* `*` indicate parameters and how many bits are used.
 
 ```cpp
 // WDC6502
@@ -38,13 +37,13 @@ cmp *16        ;$cd =a
 cmp *08        ;$c5 =a
 ```
 
-This compare's come in a lot of syntax flavor's, huh? But this is it. It's just a flavor. The only functional stuff on the left side indicates that we have `08` and `16` bit parameters. And thats allready the whole syntax: Alot of fancy ASCII plus some pointers what of it is actually interesting for us.
+These compares come in a lot of syntax flavors, huh? But this is it. It's just a flavor. The only functional stuff on the left side indicates that we have `08` and `16` bit parameters. And that's already the whole syntax: a lot of fancy ASCII plus some pointers are all that we care about.
 
-Remember that bass is alway working top down. On the assemply Stage we will scan top down, until the first matching line. Everything behind this line will be ignored.
+Remember that bass is always working top down. In the assembly stage we scan top down, until the first matching line. Everything beyond this line will be ignored.
 
 
 ### RHS Tokens
-On the right side we will find out construction rule. They contain constants, parameters and instruction tokens that tell our compiler what to do with it. Lets go back to our example.
+On the right side we find our construction rules. They contain constants, parameters and instruction tokens that tell our compiler what to do. Let's go back to our example.
 
 ```cpp
 // WDC6502
@@ -56,17 +55,17 @@ cmp *08        ;$c5 =a
 ```
 `nop` -> constant value `0xEA`.
 
-`cmp *16,x` -> constant value `0xDD` followed by the two bytes of the first parameter. Parameters will always have increasing letters starting at `a` from the left to the right. `=` indicates that we *strong* expect `a` to be an 16-Bit value. If not, this line will not match.
+`cmp *16,x` -> constant value `0xDD` followed by the two bytes of the first parameter. Parameters will always have increasing letters starting at `a` from the left to the right. `=` indicates that we *strongly* expect `a` to be an 16-bit value. If not, this line will not match.
 
-`cmp *08,x` -> constant value `0xDD` followed by that bytes of the first parameter. Again we expect a perfect match in terms of the used bit's.
+`cmp *08,x` -> constant value `0xDD` followed by the byte of the first parameter. Again we expect the parameter to exactly match the declared width (8 bits, in this case).
 
-Since the scanner works top down it is important to know when to demand exact `!`, strong `=` or weak `~` fitting values. On this architecture we would never reach the second line 
+Since the scanner works top down it is important to know when to demand exact `!`, strong `=` or weak `~` fitting values. On the following architecture we would never reach the second line:
 
 ```cpp
 cmp *16        ;$cd ~a
 cmp *08        ;$c5 =a
 ```
-Because an 8-Bit value would always fit into an 16-Bit-or-less parameter as we indicate it here.
+...because an 8-bit value would always fit into an 16-bit-or-less parameter as we indicate it here.
 
 > **Note:**<br>
 > The following list is under construction.
@@ -75,7 +74,7 @@ Code | Descr | Example
 --- | --- | ---
 `$` | hex constant | `nop ;$ea`
 `%` | binary constant | `nop ;%1110 %1010`
-`!` | exact value required | `cmp *16  ;$cd !a` needs exact 16 bit param
+`!` | exact value required | `cmp *16  ;$cd !a` needs exactly 16-bit param
 `=` | strict value required | `cmp *16 ;$cd =a`
 `~` | weak value required | `cmp *16 ;$cd ~a`
 `+` | foo | `todo`
@@ -90,19 +89,19 @@ Code | Descr | Example
 
 
 ### Commands
-Commands can and should be used to set the assembler into the right operation state. 
+Commands can and should be used to set the assembler into the right operation state.
 
-Each architecture description that is not calling `#endian` and `#directive` on it's first rows can be considered as dangerous. Autors should never expect the users to not mix different architecture files so wild that they destroy any kind of 'default behavior'.
+Each architecture description that does not call `#endian` and `#directive` in the first few lines can be considered dangerous. Authors should never assume "default behaviour", so that users can mix and match architectures in the same project as they need to.
 
-#### `#directive <name> <bytesize>` 
-Defines that the directive `name` will have exactly THIS `<bytesize>`. 
+#### `#directive <name> <bytesize>`
+Defines that the directive `name` will be exactly `<bytesize>` bytes.
 
 Default values are:
 ```cpp
 {"db", 1}, {"dw", 2}, {"dl", 3}, {"dd", 4}, {"dq", 8}
 ```
 > **Note:**<br/>
-> If you mix different architectures back and forth it might be that architecture `b` is setting custom directives, but `a` is not. This means that `b` changes the sizes, and `a` do not change them back. This leads to an very stupid error that is hard to track. Whenever you write an custom architecture make sure, to set the directives!
+> If you mix different architectures back and forth it might be that architecture B sets custom directives, but architecture A does not. This means that B changes the sizes, and A does not change them back. This can lead to very stupid errors that are hard to trace. Whenever you write a custom architecture, make sure to set all the directives!
 
 #### `#endian msb` and `#endian lsb`
 Set the current architecture to be big or little endian.
@@ -113,24 +112,24 @@ Includes the full content of `<path/name>.arch` file into the current one
 ## Custom Backends
 Tables have two big flaws
 
-* They are not as fast as real code since alot of string compares are used for each Instruction. Compiling huge projects can and will be slow
+* They are not as fast as real code since a lot of string compares are used for each instruction. Compiling huge projects can and will be slow
 * They are dumb. Complex architectures and nested register features result to large architecture files, since there is no way to handle them in a smarter way.
 
-But there is a solution for both: Extend the bass source code and handle some the whole compiling, or just parts of it using custom c++ routines.
+But there is a solution for both: Extend the bass source code and handle some or all of the assembling using custom C++ routines.
 
-### The architecture Interface
+### The architecture interface
 `todo`
 
-### Add an hardcoded backend
-Given your new Architecture is called `foo` and you want to add it into bass just follow this steps:
+### Add a hardcoded backend
+Given your new Architecture is called `foo` and you want to add it into bass just follow these steps:
 
 **1.** Create a the new subfolder for your Architecture like `bass/architecture/foo/`
 
-**2.** Create `foo.hpp` in your new folder and fill it with an minimalistic struct like 
+**2.** Create `foo.hpp` in your new folder and fill it with an minimalistic struct like
 ```cpp
 struct Foo : Architecture {
   Foo(Bass& self);
-  
+
   // called on each assemply line:
   auto assemble(const string& statement) -> bool override;
 };
@@ -146,7 +145,7 @@ auto Foo::assemble(const string& statement) -> bool {
   return true;
 }
 ```
-The `assemble` command will be called for each assembly line thats need an binary output. This lines will allready represent the static output after macro features and everything else are done with working.
+The `assemble` command will be called for each assembly line that needs a binary output. These lines already represent the static output after macro features and everything else have completed.
 
 `TODO: more?`
 
@@ -165,5 +164,5 @@ else {
 **6.** Notice that implementing an full assembler from scratch is too much work, and use the 'extend' approach instead.
 
 
-### Extend the Table Backend
+### Extend the table backend
 `todo`

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -1,10 +1,10 @@
 ![bass](bass.svg)
 
-# Bass Core Features
-Bass includes a strong macro language that offers alot of comfort compared to most classic assemblers. Macros are 'smart copy scripts' that move around code to ease the programmers work. They provide a function for copying and inserting sections of code. They do not include any understanding of the copied sections of code - they are a meta language not aimed at extending the functionality of the assembler. It is important not to confuse them with the actual program.
+# bass Core Features
+bass includes a strong macro language that offers a lot of comfort compared to most classic assemblers. Macros are 'smart copy scripts' that move around code to ease the programmers work. They automate copying and inserting sections of code. They do not include any understanding of the copied sections of code - they are a meta language not aimed at extending the functionality of the assembler. It is important not to confuse them with the actual program.
 
->**Note:**<br/> 
->Bass works using an multi-pass approach. On the first pass, all macro functions are resolved. On the second pass, the binary output is generated.
+>**Note:**<br/>
+>bass works using an multi-pass approach. On the first pass, all macro functions are resolved. On the second pass, the binary output is generated.
 
 ## Data Types
 ### Names
@@ -18,7 +18,7 @@ Macros, functions, definitions, variables and constants must follow this format:
 Valid numbers must follow one of these formats:
 
 ```regex
-[0-9]+       integer
+[0-9]+       decimal
 0b[01]+      binary
 0o[0-7]+     octal
 0x[0-9a-f]+  hex
@@ -31,7 +31,7 @@ Numbers may have either - or + as a prefix if desired.
 Numbers may also use ' as a separator between digits. For example:
 
 ```regex
-123'456'789  //same as 123456789
+123'456'789   //same as 123456789
 0b1001'0110   //same as 0b10010110
 ```
 
@@ -44,7 +44,7 @@ Strings are encompassed by double-quotes. The following escape sequences for str
 \" = double-quote (")
 \n = new line
 \t = tab
-``` 
+```
 
 Strings may also be concatenated using the ~ operator. This can be used for string construction using definitions:
 
@@ -53,16 +53,15 @@ Strings may also be concatenated using the ~ operator. This can be used for stri
 ```
 
 ### Characters
-Characters are encompassed by single-quotes. Tnteger values used inside of expression are evaluated. Characters support the same escape sequences as strings.
+Characters are encompassed by single-quotes. Integer values used inside of expression are evaluated. Characters support the same escape sequences as strings.
 
 > **Note** that characters are not escaped for block tokenization. That means '\b' must be used instead of ';' to avoid splitting the character into two separate statements.
 
-
 ## Syntax:
-In Bass, the semicolon acts as a statement separator (and not as a statement terminator). This means that a semicolon is not required at the end of each line. 
+In bass, the semicolon acts as a statement separator (and not as a statement terminator). This means that a semicolon is not required at the end of each line.
 
 ### Variables and Constants
-Variables and constants fulfill the same function as in common programming languanges. Both are constructs inside of the macro engine. By default they are not present in the target system but only in the compilers virtual machine.
+Variables and constants fulfil the same function as in common programming languages. Both are constructs inside of the macro engine. By default they are not present in the target system but only in the compilers virtual machine.
 
 ```as
 // v15-18
@@ -76,7 +75,7 @@ print a, "\n"   // prints "28\n"
 Variables and constants do not share the same namespace. This means that he `constant a` is not the same as the `variable a`. If both are present **variables** will be used first. More about this behaviour can be found at the *Scopes* Section.
 
 ## if, else, while
-Bass supports traditional conditional expressions.
+bass supports traditional conditional expressions.
 
 ```as
 // v15-18
@@ -115,7 +114,7 @@ while i < array.size(x) {   // see array.size build in function
 ````
 
 ## Expressions
-All expressions use an parentheses syntax like `{x}`. This seperates them from any variables and constants. However, they can be mixed. 
+All expressions use an parentheses syntax like `{x}`. This separates them from any variables and constants. However, they can be mixed.
 
 ### Definitions
 Definitions (using the command sequence define) store content without any interpretation. Since it is possible to use definitions in combination with parameters as a construction rule, the impression that they can be used like macros and functions can arise. This is not the case: While they do return a result, this result is only a constructed string without any interpretation. More about constructing definitions can be read in the Macros Section of this Document.
@@ -129,7 +128,7 @@ define c = (4+3)
 print "{a}{b}{c}\n"   // prints "Hello"World5.1(4+3)\n
 ```
 
-Definitions are evaluated in order from right to left. An expression such as `{x{y}`} will first expand `{y}`, and then the result of that expression, `{x...}`. In case of an unknown definition (in terms of scope) no error will be trown. The definition will be passed unresolved to allow manual evaluation.
+Definitions are evaluated in order from right to left. An expression such as `{x{y}`} will first expand `{y}`, and then the result of that expression, `{x...}`. In case of an unknown definition (in terms of scope) no error will be thrown. The definition will be passed unresolved to allow manual evaluation.
 
 Definitions are not constant and can be redefined. It is possible to test if a definition has been declared by using the following syntax:: `{defined <name>}`
 
@@ -167,11 +166,11 @@ define x = 1 + a
 print {x}, "\n"        //also prints "3\n"
 ```
 
-This is due to `print` taking each argument as evaluating parameter. More on this topic is in the section on 'Macros and Functions'. 
+This is due to `print` taking each argument as evaluating parameter. More on this topic is in the section on 'Macros and Functions'.
 
 
 ## Labels
-Like in every other assembler it is possible to 'label' a certain point within the code and use this adress within the program.
+Like in every other assembler it is possible to 'label' a certain point within the code and use this address within the program.
 
 ```as
 architecture snes.cpu
@@ -213,15 +212,15 @@ Its also possible to use labels without names by using `-` and `+`.
 +; bra --  //D: go to A
 ```
 
-The previous `-` label can be referenced with `-`. The next `+` label can be referenced with `+`. The label before the `-` label can be referenced with `--`. The label after the `+` label can be referenced with `++`. 
+The previous `-` label can be referenced with `-`. The next `+` label can be referenced with `+`. The label before the `-` label can be referenced with `--`. The label after the `+` label can be referenced with `++`.
 
 Deeper scoping is not supported. Named labels have to be used to address additional scopes.
 
 ## Namespaces
-Macros, definitions, expressions, variables, arrays and constants have a scope. This allows reuse of common names like loop and finish inside of scopes without causing declaration collisions. 
+Macros, definitions, expressions, variables, arrays and constants have a scope. This allows reuse of common names like loop and finish inside of scopes without causing declaration collisions.
 
 **Note:**<br/>
-> In bass this also means that these elements do not share the *same* scope. Macros, definitions, expressions, variables, arrays and constants **DO NOT** share the same Namespace. Instances of all these elements with the same name are possible without collision .<br/>
+> In bass this also means that these elements do not share the *same* scope. Macros, definitions, expressions, variables, arrays and constants **DO NOT** share the same namespace. Instances of all these elements with the same name are possible without collision .<br/>
 > Note: This is considered dangerous behaviour of bass and might change soon.
 
 ```as
@@ -239,16 +238,16 @@ print "-", information.length, "\n"
 // +16, +32, -16, -32
 ```
 
-Each Namespace can contain the same elements as the root Namespace could. All scopes get parsed and progressed together with the code itself.
+Each namespace can contain the same elements as the root namespace could. All scopes get parsed and progressed together with the code itself.
 
 ## Macros, Generators and Functions
-Bass gives provides some options when it comes to write macros and "functions". The old fashioned definition of a function (in terms of programming languages) is `A callable block of programm code that accepts input parameters and returns a result`. 
+bass gives provides some options when it comes to write macros and "functions". The old fashioned definition of a function (in terms of programming languages) is "a callable block of program code that accepts input parameters and returns a result".
 
 By this definition bass does *not* support functions. At least not now.
 
-Right now, `defines` which support having parameters and return a value. But due to their functional nature they do not contain a code block which could hold assembly instructions.
+Currently, bass supports `define`s which take parameters and return a value. But due to their functional nature they do not contain a code block which could hold assembly instructions.
 
-In addition, `macros` which take parameters and contain a code block for assembly instructions are available. But these do not return a result.
+In addition, bass supports `macros` which take parameters and contain a block of assembly instructions, but these do not return a result.
 
 But why can a define return an inline-result and macros can not? Let us follow this example:
 
@@ -259,16 +258,16 @@ lda #x, foo(baa, x, 12)
 ```
 A define can return a certain value without creating any cpu code on the target system. So everything is fine.
 
-A macro most likeley *will* create code on the target system. But where to put it? 
-  - At **Point A** we would create strange side effects between the macro code and the 'global' code. There is no branch called. There is no routine that saves our registers to stack and pop's them back when the macro body is ready. We cannot even be sure there *is* a stack on the unknown target system. In fact we know nothing about the target system. We are just an generic macro language.
-  - At **Point B** it's obviously too late. 
+A macro most likely *will* create code on the target system. But where to put it?
+  - At **point A** we would create strange side effects between the macro code and the 'global' code. There is no branch called. There is no routine that saves our registers to stack and pops them back when the macro body is ready. We cannot even be sure there *is* a stack on the unknown target system. In fact we know nothing about the target system. We are just an generic macro language.
+  - At **point B** it's obviously too late.
 
-So in conclusion the reason is simple: Because this is not an real programming language, and you are not using a compiler. 
+So in conclusion the reason is simple: Because this is not a real programming language, and you are not using a compiler.
 
-Defines and Macros are handy tools that allows you to wrap your 'dirty machine code' into a nice candy package. But on the end of the Day this are limitations by design.
+Defines and Macros are handy tools that allows you to wrap your 'dirty machine code' into a nice candy package. But at the end of the day, these limitations are by design.
 
 ### Generator Defines
-We allready spoke about defines. But there is a certain reason why we go back to them again: They can hold parameters and a production rule. If you call your define with that parameters you get an result. Just like if you would call a function.
+We already spoke about defines. But there is a certain reason why we go back to them again: they can hold parameters and a production rule. If you call your define with that parameters you get a result, just like if you would call a function.
 
 ```as
 define sum(x, y) = ({x} + {y})
@@ -276,7 +275,7 @@ lda #x, sum(1,1)
 ```
 
 **Note:**<br>
-> Even though it's not a bug, but more 'not a feature': You cannot nest definition calls. Not linear, and of course not recursive. At the moment its not possible to call other generators
+> Even though it's not a bug, but more 'not a feature': You cannot nest definition calls. Not linearly, and of course not recursively. At the moment its not possible to call other generators
 
 ### Macros
 Macros can take zero or more arguments, and name overloading with differing arity is possible. Recursion is supported, but requires conditionals in order to break infinite recursion. Macros must be declared before being used, and can be re-declared later on.
@@ -299,7 +298,7 @@ macro test(define a, evaluate b, variable c, d) {
 test(1+2, 1+2, 1+2, 1+2)   //{ a } = 1+2, { b } = 3, c = 3, { d } = 1+2\n
 ```
 
-So macros can be invoked with the syntax: 
+So macros can be invoked with the syntax:
 ```html
 macroName(<parameterA>, <parameterB>, ...)
 ```
@@ -308,7 +307,7 @@ If a macro is not matched, there is no error, the literal macroName(...) will be
 
 You can also use labels in macros. But because expanded macros are passed directly to the assembler, a macro with a label name cannot be expanded twice in the same scope, or the label name will be declared twice, resulting in an error. The special token `{#}` can be used in a label name, where it will be substituted with a numeric value that increments every time a macro is invoked.
 
-Example: 
+Example:
 ```as
 macro test() {
   foo{#}:
@@ -358,7 +357,7 @@ print factorial.result, "\n"  //prints 3628800
 As you see the keywords `global` and `parent` you might ask 'Why?' since you may expect that they are not needed since you have nested scopes just as in other languages. But no, bass up to version 17 do **not** has nested scopes. You can access the global, and the parent frame. But this is all you got. Even thought you can open deeper namespaces than just this.
 
 **Note:**<br/>
-> Bass v18 and above do support nested scopes.
+> bass v18 and above do support nested scopes.
 
 ### Inline macros
 Macros can also be created without a stack frame by using the `inline` keyword, which will cause any objects created inside of them to appear in the same frame as the macro was invoked in. For example:
@@ -377,15 +376,14 @@ print main.result, "\n"  //prints 256
 
 This is obviously not a good idea to use for recursive macros.
 
-## Build in Functions and Commands
-This is a list of all build in functions and commands. The difference between both groups is not only the Syntax, but also the fact, that commands are used to controll the way how bass is compiling your code. 
-Build-in-Functions on the other hand works and act like hand written macros.
+## Built-in Functions and Commands
+This is a list of all built-in functions and commands. The difference between these groups is not only the syntax, but also that commands are used to control the way how bass compiles your code, while built-in functions act like hand written macros.
 
->**Note:**<br/> 
->Please note that the syntax for Commands and Build-in-Functions is somewhat simular. It is most likely that many commands will be removed and be replaced with an set of namespace scoped build-in-functions in the future.
+>**Note:**<br/>
+>Please note that the syntax for commands and built-in functions is similar. It is most likely that many commands will be removed and be replaced with a set of namespace-scoped built-in functions in the future.
 
 * [Commands](./commands.md)
-* [Build in Functions](./buildinfunctions.md)
+* [Built-in functions](./built-in-functions.md)
 
 
 ## Final Words

--- a/doc/built-in-functions.md
+++ b/doc/built-in-functions.md
@@ -27,7 +27,7 @@ Syntax:
 ```html
 pc()
 ```
-Returns the current programm counter (origin + base).
+Returns the current program counter (origin + base).
 
 
 
@@ -36,14 +36,14 @@ Returns the current programm counter (origin + base).
 ## array.size()
 Syntax:
 ```html
-array.exists(<name>)
+array.size(<name>)
 ```
 Returns the number of elements in an array, or produces an error if the array is not defined.
 
 ## array.sort()
 Syntax:
 ```html
-array.exists(<name>)
+array.sort(<name>)
 ```
 Sorts the specified array in ascending order.
 
@@ -68,9 +68,9 @@ Returns the size of `<filename>` on disk, or produces an error if the file is no
 ## read()
 Syntax:
 ```html
-read(<adress>)
+read(<address>)
 ```
 Reads a byte from the currently open output file, or produces an error if there is no file currently open. The address provided is the origin, or literal file address. The base offset is not factored in when this function is used.
 
->**Note:**<br/> 
+>**Note:**<br/>
 > The resulting values read from a target file are only valid during the write phase of assembly! If you rely on the value read back during a previous pass to control outputting code, bass may assemble the source code incorrectly. Use this function with caution. It is mostly intended for when bass is used in patching mode.

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1,9 +1,9 @@
 # Base Commands
 
 ## architecture, arch
-The main difference between Bass and most other assemblers is, that it does not target to an single architecture or system. Thanks to its table driven approach it's possible (and yet necessary) to choose the target architecture. 
+The main difference between bass and most other assemblers is, that it does not target to an single architecture or system. Thanks to its table driven approach it's possible (and yet necessary) to choose the target architecture.
 
-It is possible (but not recomended) to switch back and forth between multiple architectures at any time.
+It is possible (but not recommended) to switch back and forth between multiple architectures at any time.
 
 Syntax:
 ```html
@@ -11,7 +11,7 @@ architecture <name>
 ```
  * `<name>` - Switch to this target architecture by looking for the file `architectures/<name>.arch`. First it will look in `~/bass/`, then relative to the location of itself.
 
->**Note:**<br/> 
+>**Note:**<br/>
 > `arch` is deprecated and might be removed soon.
 
 ## base
@@ -22,7 +22,7 @@ base <offset>
 This command creates a signed displacement against the origin value, which is used when computing the pc (program counter) value for labels. This command allows mapping file address space into a virtual memory address space. It could be used for subsystems or bank switching.
 
 ## db, dw, dl, dd, dq, ...
-Inserts binary data directly into the target file. 
+Inserts binary data directly into the target file.
 
 Syntax:
 ```html
@@ -30,16 +30,16 @@ db ("<string>" | <variable> | <const>) [, ...]
 ```
 
 Sizes:
-command | size
---- | --- 
-`db` | 1 Byte
-`dw` | 2 Byte
-`dl` | 3 Byte
-`dd` | 4 Byte
-`dq` | 8 Byte
- 
->**Note:**<br/> 
-> Like `Integer` in other languages the length of this commands depends on the architecture. Besides of `db` all sizes may change from architecture to architecture. Whenever you activate one.
+| command | size   |
+| ---     | ---    |
+| `db`    | 1 Byte |
+| `dw`    | 2 Byte |
+| `dl`    | 3 Byte |
+| `dd`    | 4 Byte |
+| `dq`    | 8 Byte |
+
+>**Note:**<br/>
+> Like "integer" in other languages, the byte-length of these commands depends on the architecture. Besides `db`, all sizes may change as you switch between architectures.
 
 ## delete
 Syntax:
@@ -62,13 +62,13 @@ endian <lsb | msb>
 ```
 This command controls whether multi-byte values (eg from dw and dd) are output in little-endian (lsb) or big-endian (msb) format.
 
->**Note:**<br/> 
+>**Note:**<br/>
 > Most architectures (should) call this command when they get activated. This may lead to confusion, so keep it in mind.
 
 ## copy
 Syntax:
 ```html
-copy <source_adress>, <target_adress>, <length>
+copy <source_address>, <target_address>, <length>
 ```
 This command copies a block from the currently open file to another location within the file. It does this by reading the entire block in first, and then writing said block out, so be careful with overlapping addresses.
 
@@ -86,8 +86,8 @@ include "<filename>"
 ```
 Includes another source file in place of this command.
 
->**Note:**<br/> 
-> This command is parsed in the very first phase, and is only noted here for  completeness. At the time when include get applied no other commands had been progressed. So do not attempt conditional recursion on the same source file, as this will result in an infinite loop which will eventually exhaust all memory. 
+>**Note:**<br/>
+> This command is parsed in the very first phase, and is only noted here for completeness. At the time when `include` is applied, no other commands have been processed, so do not attempt conditional recursion on the same source file or you'll get an infinite loop which will eventually exhaust all memory.
 
 ## insert
 Syntax:
@@ -103,14 +103,14 @@ map <char> [, <value>] [, <length>]
 ```
 Modifies the mappings for strings passed to db, dw, etc. This can be used to map strings to custom tilemaps that do not follow traditional ASCII values.
 
-`<char>` is the first value to modify, `<value>` is the value to map said char to, and `<length>` can be used for contiguous entries. 
+`<char>` is the first value to modify, `<value>` is the value to map said char to, and `<length>` can be used for contiguous entries.
 
-For instance, if A-Z appear sequentially, give a value of 26 for the length, to avoid having to declare 26 separate assignments. 
+For instance, if A-Z appear sequentially, give a value of 26 for the length, to avoid having to declare 26 separate assignments.
 
 ```cpp
 map 'a', 0x01, 26
 ```
-Each step of length increments both the char and value by exactly one, so the characters must be contiguous with both ASCII and your custom map for this to work.
+Each step of `<length>` increments both the char and value by exactly one, so the characters must be contiguous with both ASCII and your custom map for this to work.
 
 If you wish to restore the table to its default ASCII values, use the following command:
 ```cpp
@@ -134,7 +134,7 @@ This command can be used in place of the `-o filename [-create]` command-line ar
 ## print (notice, warning, error)
 Prints information to the terminal. Useful for debugging. Using `error` aborts assembly, all other functions will not.
 
-Print is the swiss army knife of all commands. It allows you to print multiple parameters to the screen. Strings, Characters, Numbers, Variables, Constants and Defines works.
+`print` is the Swiss Army knife of all commands. It allows you to print multiple parameters to the screen. Strings, Characters, Numbers, Variables, Constants and Defines all work.
 
 Syntax:
 ```html
@@ -150,8 +150,8 @@ print "$", hex:65536     //prints $10000
 print "'", char:65, "'"  //prints 'A'
 ```
 
->**Note:**<br/> 
-> Defined parameters will be evaluated as single parameter, but just be referenced when used inside of a string.<br/>
+>**Note:**<br/>
+> Defined parameters will be evaluated as single parameter, but will be pasted verbatim inside of a string.<br/>
 > Example:
 > ```as
 > // v15-18
@@ -159,13 +159,13 @@ print "'", char:65, "'"  //prints 'A'
 > define x = 1 + a
 > print {x}, ", {x}\n"        // prints "3, 1 + a\n"
 > ```
-> This may lead to wrong assumptions about the strings content if you debug using print commands. 
+> This may lead to wrong assumptions about the strings content if you debug using print commands.
 
 ## Queues
-The queue feature works like a smal stack for certan system states `<state>` such as `origin`, `base` and `pc`. It works in a 'last in first out' manner.
+The queue feature works like a small stack for certain system states `<state>` such as `origin`, `base` and `pc`. It works in a 'last in first out' manner.
 
->**Note:**<br/> 
-> Right now all values share one queue! In other words you should be very carefull about the order if you 'store' and 'reload' many values at once. <br/>
+>**Note:**<br/>
+> Right now all values share one queue! In other words you should be very careful about the order if you 'store' and 'reload' many values at once. <br/>
 > We consider this as dangerous. The feature will redesigned in the near future.
 
 ### dequeue

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,27 +1,27 @@
 ![bass](bass.svg)
 
-# Bass
+# bass
 
-Bass is a table-based, multi-architecture and cross-platform, macro assembler developed by Near up until version 17. It is targeted at developers and hackers interested in legacy video game consoles such as NES, SNES, MegaDrive and others.
+bass is a table-based, multi-architecture and cross-platform, macro assembler developed by Near up until version 17. It is targeted at developers and hackers interested in legacy video game consoles such as the NES, SNES, MegaDrive and others.
 
-**Bass is for you if:**
-  * you want or need to work low level 
+**bass is for you if:**
+  * you want or need to work low level
   * you want to avoid dependencies
-  * you target obscure systems that lack any other compiler 
+  * you target obscure systems that lack any other compiler
   * you want to build your own compiler
-  * you want extensive macro features allowing you to work similiar to using a higher programming language
+  * you want extensive macro features giving you the convenience of a higher-level programming language
   * you want the ability to do root level debugging
 
 **This is not for you if:**
-  * you look for a higher 'real' programming language
-  * you expect an complete toolchain that takes care about all your needs
+  * you want an actual high-level programming language
+  * you expect an complete toolchain that takes care of all your needs
 
 
 ## Available supporting documents
 **Documentation**
-  * [Bass Core Features](basics.md)
+  * [bass Core Features](basics.md)
     * [Commands](./commands.md)
-    * [Built-in functions](./buildinfunctions.md)
+    * [Built-in functions](./built-in-functions.md)
   * [Architectures](architectures.md)
 
 **Tutorials**


### PR DESCRIPTION
Changes include:

- "bass" is always lowercase, even at the beginning of a sentence. It's not grammatically "correct", but Near was always pretty insistent.
- Removed trailing spaces.
- Made some capitalised words lower-case when they weren't at the beginning of a sentence, or naming a specific thing.
- Changed some wording to flow more naturally.
- Changed "LFH" (not sure what this means) to "LHS" (left-hand side) to match "RHS" (right-hand side)
- Checked the spelling of all documents, fixed typos.
- Renamed "build in functions" to "built-in functions" consistently