### PR TITLE
Fix old and new syntax for constant/define/evaluate/variable

### DIFF
--- a/bass/core/assemble.cpp
+++ b/bass/core/assemble.cpp
@@ -43,16 +43,12 @@ auto Bass::assemble(const string& statement) -> bool {
     return true;
   }
 
-  //constant name(value)
-  //or
-  //constant name = value
   if(s.match("constant ?*")) {
-    if (s.match("*(*")){
-      auto p = s.trim("constant ", ")").split("(");
-      setConstant(p(0), evaluate(p(1)));
-    }
-    else {
+    if(s.contains("=")) {
       auto p = s.trimLeft("constant ", 1L).split("=", 1L).strip();
+      setConstant(p(0), evaluate(p(1)));
+    } else {
+      auto p = s.trim("constant ", ")", 1L).split("(", 1L).strip();
       setConstant(p(0), evaluate(p(1)));
     }
     return true;

--- a/bass/core/execute.cpp
+++ b/bass/core/execute.cpp
@@ -58,33 +58,28 @@ auto Bass::executeInstruction(Instruction& i) -> bool {
     return true;
   }
 
-  if(s.match("define ?*(*)*")) {
-    auto e = s.trimLeft("define ", 1L).split("=", 1L).strip();
-    auto p = e(0).trimRight(")", 1L).split("(", 1L).strip();
-    auto parameters = split(p(1));
-    setDefine(p(0), parameters, e(1), level);
-    return true;
-  }
-
   if(s.match("define ?*")) {
-    if (s.match("*(*")) {
-      auto p = s.trim("define ", ")").split("(");
+    if(s.contains("=")) {
+      auto e = s.trimLeft("define ", 1L).split("=", 1L).strip();
+      auto p = e(0).trimRight(")", 1L).split("(", 1L).strip();
+      auto parameters = split(p(1));
+      setDefine(p(0), parameters, e(1), level);
+    } else if(s.contains("(")) {
+      auto p = s.trim("define ", ")", 1L).split("(", 1L).strip();
       setDefine(p(0), {}, p(1), level);
-    }
-    else {
-      auto p = s.trimLeft("define ", 1L).split("=", 1L).strip();
-      setDefine(p(0), {}, p(1), level);
+    } else {
+      auto p = s.trimLeft("define ", 1L).strip();
+      setDefine(p, {}, {}, level);
     }
     return true;
   }
 
   if(s.match("evaluate ?*")) {
-    if (s.match("*(*")) {
-      auto p = s.trim("evaluate ", ")").split("(");
-      setDefine(p(0), {}, evaluate(p(1)), level);
-    }
-    else {
+    if(s.contains("=")) {
       auto p = s.trimLeft("evaluate ", 1L).split("=", 1L).strip();
+      setDefine(p(0), {}, evaluate(p(1)), level);
+    } else {
+      auto p = s.trim("evaluate ", ")", 1L).split("(", 1L).strip();
       setDefine(p(0), {}, evaluate(p(1)), level);
     }
     return true;
@@ -99,12 +94,11 @@ auto Bass::executeInstruction(Instruction& i) -> bool {
   }
 
   if(s.match("variable ?*")) {
-    if (s.match("*(*")){
-      auto p = s.trim("variable ", ")").split("(");
-      setVariable(p(0), evaluate(p(1)), level);
-    }
-    else {
+    if(s.contains("=")) {
       auto p = s.trimLeft("variable ", 1L).split("=", 1L).strip();
+      setVariable(p(0), evaluate(p(1)), level);
+    } else {
+      auto p = s.trim("variable ", ")", 1L).split("(", 1L).strip();
       setVariable(p(0), evaluate(p(1)), level);
     }
     return true;

--- a/test/old_and_new/constant.asm
+++ b/test/old_and_new/constant.asm
@@ -1,0 +1,15 @@
+
+constant   old_style_a(3 + (25 * 2) + 3)
+constant   new_style_a=3 + (25 * 2) + 3
+
+constant   old_style_b   (   3 + (25 * 2) + 3)
+constant   new_style_b   =   3 + (25 * 2) + 3
+
+if old_style_a != new_style_a {
+    error "defines are not equal"
+}
+if old_style_b != new_style_b {
+    error "defines are not equal"
+}
+print "PASS\n"
+

--- a/test/old_and_new/define-args.asm
+++ b/test/old_and_new/define-args.asm
@@ -1,0 +1,12 @@
+
+define   double_a(i)=(2 * {i})
+define   double_b(i)   =   (2 * {i})
+
+if {double_a(12)} != 24 {
+    error "Test failed"
+}
+if {double_b(24)} != 48 {
+    error "Test failed"
+}
+print "PASS\n"
+

--- a/test/old_and_new/define-no-expression.asm
+++ b/test/old_and_new/define-no-expression.asm
@@ -1,0 +1,8 @@
+
+define  NO_EXPRESSION
+
+if !{defined NO_EXPRESSION} {
+    error "Test failed"
+}
+print "PASS\n"
+

--- a/test/old_and_new/define.asm
+++ b/test/old_and_new/define.asm
@@ -1,0 +1,15 @@
+
+define   old_style_a(3 + (25 * 2) + 3)
+define   new_style_a=3 + (25 * 2) + 3
+
+define   old_style_b   (   3 + (25 * 2) + 3)
+define   new_style_b   =   3 + (25 * 2) + 3
+
+if ({old_style_a}) != ({new_style_a}) {
+    error "defines are not equal"
+}
+if ({old_style_b}) != ({new_style_b}) {
+    error "defines are not equal"
+}
+print "PASS\n"
+

--- a/test/old_and_new/evaluate.asm
+++ b/test/old_and_new/evaluate.asm
@@ -1,0 +1,15 @@
+
+evaluate   old_style_a(3 + (25 * 2) + 3)
+evaluate   new_style_a=3 + (25 * 2) + 3
+
+evaluate   old_style_b   (   3 + (25 * 2) + 3)
+evaluate   new_style_b   =   3 + (25 * 2) + 3
+
+if ({old_style_a}) != ({new_style_a}) {
+    error "defines are not equal"
+}
+if ({old_style_b}) != ({new_style_b}) {
+    error "defines are not equal"
+}
+print "PASS\n"
+

--- a/test/old_and_new/variable.asm
+++ b/test/old_and_new/variable.asm
@@ -1,0 +1,15 @@
+
+variable   old_style_a(3 + (25 * 2) + 3)
+variable   new_style_a=3 + (25 * 2) + 3
+
+variable   old_style_b   (   3 + (25 * 2) + 3)
+variable   new_style_b   =   3 + (25 * 2) + 3
+
+if old_style_a != new_style_a {
+    error "defines are not equal"
+}
+if old_style_b != new_style_b {
+    error "defines are not equal"
+}
+print "PASS\n"
+


### PR DESCRIPTION
This fixes the show-stopper I mentioned in PR #36 

<br/>

Besides the included tests, this PR has been tested against:
 * [untech-engine](https://github.com/undisbeliever/untech-engine) (bass-v15 syntax)
 * [snes-test-roms](https://github.com/undisbeliever/snes-test-roms) (bass-v15 syntax)
 * 5 samples from https://github.com/PeterLemon/SNES (bass-v14 syntax)


